### PR TITLE
Fixed link to contact page in nav bar

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -24,6 +24,3 @@ get '/layout' do
 erb :layout
 end
 
- #post '/sign_in' do
- # erb :contact
- # end 

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -19,7 +19,7 @@
 				<li class="li_navbar"><a href="/about" class="a_nav">About</a></li>
 				<li class="li_navbar"><a href="/menu" class="a_nav">Menu</a></li>
 				<li class="li_navbar"><a href="/reservation" class="a_nav">Reservations</a></li>
-				<li class="li_navbar"><a href"/contact" class="a_nav">Contact</a></li>
+				<li class="li_navbar"><a href="/contact" class="a_nav">Contact</a></li>
 			</ul>
 		</nav>
 


### PR DESCRIPTION
missing '=' in h ref, link to contact page now working. 
